### PR TITLE
Fix example code for Catalogue of Life database download

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -81,8 +81,8 @@ db_load_tpl(x)
 Cataloge of Life (COL)
 
 ```{r eval=FALSE}
-x <- db_download_itis()
-db_load_itis(x)
+x <- db_download_col()
+db_load_col(x)
 ```
 
 ## connect to the DBs

--- a/README.Rmd
+++ b/README.Rmd
@@ -78,7 +78,7 @@ x <- db_download_tpl()
 db_load_tpl(x)
 ```
 
-Cataloge of Life (COL)
+Catalogue of Life (COL)
 
 ```{r eval=FALSE}
 x <- db_download_col()

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Cataloge of Life (COL)
 
 
 ```r
-x <- db_download_itis()
-db_load_itis(x)
+x <- db_download_col()
+db_load_col(x)
 ```
 
 ## connect to the DBs

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ x <- db_download_tpl()
 db_load_tpl(x)
 ```
 
-Cataloge of Life (COL)
+Catalogue of Life (COL)
 
 
 ```r


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Corrected the form of <code>db_download_\*()</code> and <code>db_load_\*()</code> used in Catalogue of Life example.
