### PR TITLE
Fix #21

### DIFF
--- a/R/ap_name2taxid.R
+++ b/R/ap_name2taxid.R
@@ -77,7 +77,7 @@ ncbi_name2taxid <- function(src, x, empty, ...){
 
   # sort results first according to input order of names and second by taxon
   # order (which matters only for ambiguous entries)
-  result <- result[order(factor(result$name_txt, levels=x), result$tax_id), ]
+  result <- result[order(factor(result$name_txt, levels=unique(x)), result$tax_id), ]
   result$tax_id <- as.character(result$tax_id)
   # There can be repeated rows, for example 'Bacteria' and 'bacteria' are both
   # are converted into 'Bacteria', but they point to the same taxon id.

--- a/tests/testthat/test-name2taxid.R
+++ b/tests/testthat/test-name2taxid.R
@@ -25,6 +25,10 @@ test_that("name2taxid(out_type='uid') dies if ambiguous", {
   expect_error(name2taxid("Bacteria", out_type='uid'))
 })
 
+test_that("name2taxid works with duplicates", {
+  expect_equal(name2taxid(c("Arabidopsis", "Arabidopsis"), out_type='uid'), c("3701", "3701"))
+})
+
 test_that("name2taxid summary works", {
   expect_equal(
     name2taxid('dragon', out_type='summary'),


### PR DESCRIPTION
## Description

Fix #21, death on name duplicates

## Related Issue

Fix #21

## Example

Now this doesn't explode:

```R
name2taxid(c('pig', 'pig'))
```