### PR TITLE
fix bug in 'name2taxid' for organism names with underscores originally

### DIFF
--- a/R/ap_name2taxid.R
+++ b/R/ap_name2taxid.R
@@ -66,7 +66,11 @@ ncbi_name2taxid <- function(src, x, empty, ...){
   # 'Arabidopsis_thaliana' is included, but the same is NOT done for humans.
   # However, underscores are supported when querying through entrez, which
   # implies they are replacing underscores with spaces. So I do the same.
-  s = gsub('_', ' ', tolower(x))
+  # Some oganisms have underscores originally, so skip replacing if there are 
+  # already spaces. 
+  s = tolower(x)
+  has_no_space = !grepl(" ", s)
+  s[has_no_space] = gsub('_', ' ', s[has_no_space])
 
   # FYI: The schema is set to support case insensitive matches
   query <- "SELECT name_txt, tax_id FROM names WHERE name_txt IN (%s)"


### PR DESCRIPTION
For organism names with underscores originally, replacing underscores with spaces will give NA taxids, i.e. "haloarchaeon 3A1_DGR".

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some oganisms have underscores originally, so skip replacing if there are already spaces.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #41 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```r
> taxid2name("1071085")
[1] "haloarchaeon 3A1_DGR"
> taxid2name("1071085") %>% name2taxid
[1] "1071085"
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
