### PR TITLE
Transform ropensci.github.io in docs.ropensci.org

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
         email = "myrmecocystus+r@gmail.com", role = c("aut", "cre")),
     person("Zebulun", "Arendsee", role = "aut")
     )
-URL: https://ropensci.github.io/taxizedb/, https://github.com/ropensci/taxizedb
+URL: https://docs.ropensci.org/taxizedb/, https://github.com/ropensci/taxizedb
 BugReports: https://github.com/ropensci/taxizedb/issues
 License: MIT + file LICENSE
 LazyData: TRUE

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 
 `taxizedb` - Tools for Working with Taxonomic Databases on your machine
 
-Docs: <https://ropensci.github.io/taxizedb/>
+Docs: <https://docs.ropensci.org/taxizedb/>
 
 [taxize](https://github.com/ropensci/taxize) is a heavily used taxonomic toolbelt
 package in R - However, it makes web requests for nearly all methods. That is fine

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ taxizedb
 
 `taxizedb` - Tools for Working with Taxonomic Databases on your machine
 
-Docs: <https://ropensci.github.io/taxizedb/>
+Docs: <https://docs.ropensci.org/taxizedb/>
 
 [taxize](https://github.com/ropensci/taxize) is a heavily used taxonomic toolbelt
 package in R - However, it makes web requests for nearly all methods. That is fine

--- a/codemeta.json
+++ b/codemeta.json
@@ -216,5 +216,5 @@
     "r",
     "r-package"
   ],
-  "relatedLink": "https://ropensci.github.io/taxizedb/"
+  "relatedLink": "https://docs.ropensci.org/taxizedb/"
 }


### PR DESCRIPTION
Transformed all ropensci.github.io links into docs.ropensci.org ones as recommended :)