### PR TITLE
Allow the use of a custom datafiles in db_load_* functions

### DIFF
--- a/R/db_download.R
+++ b/R/db_download.R
@@ -4,6 +4,7 @@
 #' @name db_download
 #' @param verbose (logical) Print messages. Default: `TRUE`
 #' @param overwrite (logical) If `TRUE` force an update by overwriting
+#' @param path (character) If not NULL, use this file rather than downloading a new one
 #' previously downloaded data. Default: `FALSE`
 #' @return (character) path to the downloaded SQL database
 #' @details Downloads sql database, cleans up unneeded files, returns path
@@ -43,7 +44,7 @@
 
 #' @export
 #' @rdname db_download
-db_download_ncbi <- function(verbose = TRUE, overwrite = FALSE) {
+db_download_ncbi <- function(verbose = TRUE, overwrite = FALSE, path = NULL) {
   # set paths
   db_url <- 'ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdmp.zip'
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'taxdump.zip')
@@ -62,9 +63,13 @@ db_download_ncbi <- function(verbose = TRUE, overwrite = FALSE) {
 
   # make home dir if not already present
   tdb_cache$mkdir()
-  # download data
-  mssg(verbose, 'downloading...')
-  curl::curl_download(db_url, db_path_file, quiet = TRUE)
+  if(is.null(path)){
+    # download data
+    mssg(verbose, 'downloading...')
+    curl::curl_download(db_url, db_path_file, quiet = TRUE)
+  } else {
+    file.copy(path, db_path_file)
+  }
   # unzip
   mssg(verbose, 'unzipping...')
   utils::unzip(db_path_file, files = c('names.dmp', 'nodes.dmp'), exdir = db_path_dir)
@@ -215,7 +220,7 @@ db_download_ncbi <- function(verbose = TRUE, overwrite = FALSE) {
 
 #' @export
 #' @rdname db_download
-db_download_itis <- function(verbose = TRUE, overwrite = FALSE) {
+db_download_itis <- function(verbose = TRUE, overwrite = FALSE, path = NULL) {
   # paths
   db_url <- 'https://itis.gov/downloads/itisSqlite.zip'
   db_path <- file.path(tdb_cache$cache_path_get(), 'itisSqlite.zip')
@@ -232,9 +237,15 @@ db_download_itis <- function(verbose = TRUE, overwrite = FALSE) {
 
   # make home dir if not already present
   tdb_cache$mkdir()
-  # download data
-  mssg(verbose, 'downloading...')
-  curl::curl_download(db_url, db_path, quiet = TRUE)
+
+  if(is.null(path)){
+    # download data
+    mssg(verbose, 'downloading...')
+    curl::curl_download(db_url, db_path, quiet = TRUE)
+  } else {
+    file.copy(path, db_path)
+  }
+
   # unzip
   mssg(verbose, 'unzipping...')
   utils::unzip(db_path, exdir = db_path_file)
@@ -254,7 +265,7 @@ db_download_itis <- function(verbose = TRUE, overwrite = FALSE) {
 
 #' @export
 #' @rdname db_download
-db_download_tpl <- function(verbose = TRUE, overwrite = FALSE) {
+db_download_tpl <- function(verbose = TRUE, overwrite = FALSE, path = NULL) {
   db_url <- "https://taxize-dbs.s3-us-west-2.amazonaws.com/plantlist.zip" #nolint
   db_path <- file.path(tdb_cache$cache_path_get(), 'plantlist.zip')
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'plantlist')
@@ -270,9 +281,15 @@ db_download_tpl <- function(verbose = TRUE, overwrite = FALSE) {
 
   # make home dir if not already present
   tdb_cache$mkdir()
-  # download data
-  mssg(verbose, 'downloading...')
-  curl::curl_download(db_url, db_path, quiet = TRUE)
+
+  if(is.null(path)){
+    # download data
+    mssg(verbose, 'downloading...')
+    curl::curl_download(db_url, db_path, quiet = TRUE)
+  } else {
+    file.copy(path, db_path)
+  }
+
   # unzip
   mssg(verbose, 'unzipping...')
   utils::unzip(db_path, exdir = db_path_file)
@@ -288,7 +305,7 @@ db_download_tpl <- function(verbose = TRUE, overwrite = FALSE) {
 
 #' @export
 #' @rdname db_download
-db_download_wfo <- function(verbose = TRUE, overwrite = FALSE) {
+db_download_wfo <- function(verbose = TRUE, overwrite = FALSE, path = NULL) {
   db_url <- "http://104.198.143.165/files/WFO_Backbone/_WFOCompleteBackbone/WFO_Backbone.zip" #nolint
   db_path <- file.path(tdb_cache$cache_path_get(), 'WFO_Backbone.zip')
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'WFO_Backbone')
@@ -306,9 +323,13 @@ db_download_wfo <- function(verbose = TRUE, overwrite = FALSE) {
   # make home dir if not already present
   tdb_cache$mkdir()
   
-  # download data
-  mssg(verbose, 'downloading...')
-  curl::curl_download(db_url, db_path, quiet = TRUE)
+  if(is.null(path)){
+    # download data
+    mssg(verbose, 'downloading...')
+    curl::curl_download(db_url, db_path, quiet = TRUE)
+  } else {
+    file.copy(path, db_path)
+  }
   
   # unzip
   mssg(verbose, 'unzipping...')
@@ -384,7 +405,7 @@ db_download_wfo <- function(verbose = TRUE, overwrite = FALSE) {
 
 #' @export
 #' @rdname db_download
-db_download_col <- function(verbose = TRUE, overwrite = FALSE) {
+db_download_col <- function(verbose = TRUE, overwrite = FALSE, path = NULL) {
   db_url <- 'https://taxize-dbs.s3-us-west-2.amazonaws.com/col.zip'
   db_path <- file.path(tdb_cache$cache_path_get(), 'col.sqlite')
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'col.zip')
@@ -398,8 +419,14 @@ db_download_col <- function(verbose = TRUE, overwrite = FALSE) {
   unlink(db_path, force = TRUE)
 
   tdb_cache$mkdir()
-  mssg(verbose, 'downloading...')
-  curl::curl_download(db_url, db_path_file, quiet = TRUE)
+
+  if(is.null(path)){
+    # download data
+    mssg(verbose, 'downloading...')
+    curl::curl_download(db_url, db_path_file, quiet = TRUE)
+  } else {
+    file.copy(path, db_path_file)
+  }
 
   mssg(verbose, 'unzipping...')
   utils::unzip(db_path_file, exdir = tdb_cache$cache_path_get())
@@ -413,7 +440,7 @@ db_download_col <- function(verbose = TRUE, overwrite = FALSE) {
 
 #' @export
 #' @rdname db_download
-db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
+db_download_gbif <- function(verbose = TRUE, overwrite = FALSE, path = NULL) {
   db_url <- 'https://taxize-dbs.s3-us-west-2.amazonaws.com/gbif.zip'
   db_path <- file.path(tdb_cache$cache_path_get(), 'gbif.sqlite')
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'gbif.zip')
@@ -427,8 +454,14 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
   unlink(db_path, force = TRUE)
 
   tdb_cache$mkdir()
-  mssg(verbose, 'downloading...')
-  curl::curl_download(db_url, db_path_file, quiet = TRUE)
+
+  if(is.null(path)){
+    # download data
+    mssg(verbose, 'downloading...')
+    curl::curl_download(db_url, db_path_file, quiet = TRUE)
+  } else {
+    file.copy(path, db_path_file)
+  }
 
   mssg(verbose, 'unzipping...')
   utils::unzip(db_path_file, exdir = tdb_cache$cache_path_get())
@@ -442,7 +475,7 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
 
 #' @export
 #' @rdname db_download
-db_download_wikidata <- function(verbose = TRUE, overwrite = FALSE) {
+db_download_wikidata <- function(verbose = TRUE, overwrite = FALSE, path = NULL) {
   db_url <- 'https://zenodo.org/record/1213477/files/wikidata-taxon-info20171227.tsv.gz'
 
   txt_file <- file.path(tdb_cache$cache_path_get(), 'wikidata-taxon-info20171227.tsv.gz')
@@ -459,6 +492,14 @@ db_download_wikidata <- function(verbose = TRUE, overwrite = FALSE) {
   # download
   mssg(verbose, 'downloading...')
   curl::curl_download(db_url, txt_file, quiet = TRUE)
+
+  if(is.null(path)){
+    # download data
+    mssg(verbose, 'downloading...')
+    curl::curl_download(db_url, txt_file, quiet = TRUE)
+  } else {
+    file.copy(path, txt_file)
+  }
 
   # load taxa.txt
   taxa_txt <- readr::read_tsv(txt_file, skip = 1,

--- a/man/db_download.Rd
+++ b/man/db_download.Rd
@@ -11,24 +11,26 @@
 \alias{db_download_wikidata}
 \title{Download taxonomic databases}
 \usage{
-db_download_ncbi(verbose = TRUE, overwrite = FALSE)
+db_download_ncbi(verbose = TRUE, overwrite = FALSE, path = NULL)
 
-db_download_itis(verbose = TRUE, overwrite = FALSE)
+db_download_itis(verbose = TRUE, overwrite = FALSE, path = NULL)
 
-db_download_tpl(verbose = TRUE, overwrite = FALSE)
+db_download_tpl(verbose = TRUE, overwrite = FALSE, path = NULL)
 
-db_download_wfo(verbose = TRUE, overwrite = FALSE)
+db_download_wfo(verbose = TRUE, overwrite = FALSE, path = NULL)
 
-db_download_col(verbose = TRUE, overwrite = FALSE)
+db_download_col(verbose = TRUE, overwrite = FALSE, path = NULL)
 
-db_download_gbif(verbose = TRUE, overwrite = FALSE)
+db_download_gbif(verbose = TRUE, overwrite = FALSE, path = NULL)
 
-db_download_wikidata(verbose = TRUE, overwrite = FALSE)
+db_download_wikidata(verbose = TRUE, overwrite = FALSE, path = NULL)
 }
 \arguments{
 \item{verbose}{(logical) Print messages. Default: \code{TRUE}}
 
-\item{overwrite}{(logical) If \code{TRUE} force an update by overwriting
+\item{overwrite}{(logical) If \code{TRUE} force an update by overwriting}
+
+\item{path}{(character) If not NULL, use this file rather than downloading a new one
 previously downloaded data. Default: \code{FALSE}}
 }
 \value{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit adds a "path" keyword argument to the `db_download_*` files that allows the user to bypass the taxonomy database download step and use a custom local file.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Fixes #71, or at least provides a workaround.

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

``` R
# This command will
#  1. download the NCBI taxonomy dump as "taxdmp.zip" using curl and a hard-coded URL
#  2. unzip the file and build the sqlite database
db_download_ncbi()

# This command bypasses the first download step. This allows
# the user to retrieve the data from a different source, modify it,
# or use a different tool to retrieve it (e.g., wget, rsync, or whatever).
db_download_ncbi(path="taxdmp.zip")
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
