### PR TITLE
update ncbi endpoint

### DIFF
--- a/R/db_download.R
+++ b/R/db_download.R
@@ -45,7 +45,7 @@
 #' @rdname db_download
 db_download_ncbi <- function(verbose = TRUE, overwrite = FALSE) {
   # set paths
-  db_url <- 'ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdmp.zip'
+  db_url <- 'ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdmp.zip'
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'taxdump.zip')
   db_path_dir <- file.path(tdb_cache$cache_path_get(), 'taxdump')
   ncbi_names_file <- file.path(db_path_dir, 'names.dmp')


### PR DESCRIPTION
The NBCI taxonomy endpoint must have changed at one point, causing calls to `db_download_ncbi` to fail. This fixes this.

## Related Issue
May be an alternate solution to #72 (since the impetus was timeout on download)

## Examples
Might be wise to add some kind of test like

```r
"ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdmp.zip" |> curl_fetch_memory()
```
And test for no error. Might also be wise to somehow link the test URL and the package function URL so that a change in the function would invalidate the test. Seemed kinda out of scope though and also I'm not terribly sure how to do this well, so we're flying testless. 