### PR TITLE
 Prepare all SQLite databases locally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ Imports:
 Suggests:
     testthat,
     taxize
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Encoding: UTF-8
 Language: en-US
 Imports:
     curl (>= 2.4),
+    data.table,
     DBI (>= 0.6-1),
     RSQLite (>= 1.1.2),
     dplyr (>= 0.7.0),

--- a/R/ap_children.R
+++ b/R/ap_children.R
@@ -10,10 +10,10 @@
 #' equivalent to the output of `taxize::children()`
 #' @examples \dontrun{
 #' children(c(3700, 2))
-#' children(c(154395, 154357), db="itis")
-#' children("wfo-4000032377", db="wfo")
-#' children(2877951, db="gbif")
-#' children(3960765, db="col") # Abies
+#' children(c(154395, 154357), db = "itis")
+#' children("wfo-4000032377", db = "wfo")
+#' children(2877951, db = "gbif")
+#' children(3960765, db = "col") # Abies
 #' }
 children <- function(x, db='ncbi', verbose=TRUE, ...){
   ap_dispatch(x=x, db=db, cmd='children', class='children', verbose=verbose, ...)

--- a/R/ap_children.R
+++ b/R/ap_children.R
@@ -13,7 +13,7 @@
 #' children(c(154395, 154357), db = "itis")
 #' children("wfo-4000032377", db = "wfo")
 #' children(2877951, db = "gbif")
-#' children(3960765, db = "col") # Abies
+#' children("C66T4", db = "col") # Abies Mill. Mill.
 #' }
 children <- function(x, db='ncbi', verbose=TRUE, ...){
   ap_dispatch(x=x, db=db, cmd='children', class='children', verbose=verbose, ...)

--- a/R/ap_classification.R
+++ b/R/ap_classification.R
@@ -19,7 +19,7 @@
 #' classification(c("wfo-0000291463", "wfo-7000000057"), db = "wfo")
 #' classification(2878586, db = "gbif")
 #' classification(c(2878586, 2704179), db = "gbif")
-#' classification(3960765, db = "col") # Abies
+#' classification("C66T4", db = "col") # Abies Mill.
 #' }
 classification <- function(x, db='ncbi', verbose=TRUE, ...){
   ap_dispatch(

--- a/R/ap_classification.R
+++ b/R/ap_classification.R
@@ -15,11 +15,11 @@
 #' exactly equivalent to the output of `taxize::classification()`
 #' @examples \dontrun{
 #' classification(c(3702, 9606))
-#' classification(c(154395, 154357), db="itis")
-#' classification(c("wfo-0000291463", "wfo-7000000057"), db="wfo")
-#' classification(2878586, db="gbif")
-#' classification(c(2878586, 2704179), db="gbif")
-#' classification(3960765, db="col") # Abies
+#' classification(c(154395, 154357), db = "itis")
+#' classification(c("wfo-0000291463", "wfo-7000000057"), db = "wfo")
+#' classification(2878586, db = "gbif")
+#' classification(c(2878586, 2704179), db = "gbif")
+#' classification(3960765, db = "col") # Abies
 #' }
 classification <- function(x, db='ncbi', verbose=TRUE, ...){
   ap_dispatch(

--- a/R/ap_name2taxid.R
+++ b/R/ap_name2taxid.R
@@ -36,7 +36,7 @@
 #' name2taxid("Austrobaileyaceae", db = "wfo")
 #' name2taxid("Quercus kelloggii", db = "gbif")
 #' name2taxid(c("Quercus", "Fabaceae", "Animalia"), db = "gbif")
-#' name2taxid(c("Abies", "Pinales", "Tracheophyta"), db = "col")
+#' name2taxid(c("Abies Mill.", "Pinales Gorozh.", "Tracheophyta"), db = "col")
 #' name2taxid(c("Abies mangifica", "Acanthopale aethiogermanica",
 #'   "Acanthopale albosetulosa"), db = "tpl")
 #' }

--- a/R/ap_taxid2name.R
+++ b/R/ap_taxid2name.R
@@ -14,11 +14,11 @@
 #' taxid2name(c(3702, 9606))
 #' taxid2name(c(154395, 154357, 23041, 154396), db = "itis")
 #' taxid2name(c('wfo-0000541830', 'wfo-0000291463'), db = "wfo")
-#' taxid2name("wfo-7000000057", db="wfo")
-#' taxid2name(2877951, db="gbif")
-#' taxid2name(c(2877951, 5386), db="gbif")
-#' taxid2name(c(3960765, 3953606, 3953010), db="col")
-#' taxid2name(c("kew-2614538", "kew-2895433", "kew-2615007"), db="tpl")
+#' taxid2name("wfo-7000000057", db = "wfo")
+#' taxid2name(2877951, db = "gbif")
+#' taxid2name(c(2877951, 5386), db = "gbif")
+#' taxid2name(c(3960765, 3953606, 3953010), db = "col")
+#' taxid2name(c("kew-2614538", "kew-2895433", "kew-2615007"), db = "tpl")
 #' }
 taxid2name <- function(x, db='ncbi', verbose=TRUE, warn=TRUE, ...){
   result <- ap_vector_dispatch(

--- a/R/ap_taxid2name.R
+++ b/R/ap_taxid2name.R
@@ -17,7 +17,7 @@
 #' taxid2name("wfo-7000000057", db = "wfo")
 #' taxid2name(2877951, db = "gbif")
 #' taxid2name(c(2877951, 5386), db = "gbif")
-#' taxid2name(c(3960765, 3953606, 3953010), db = "col")
+#' taxid2name(c("C66T4", "C7ZVH", "TP"), db = "col")
 #' taxid2name(c("kew-2614538", "kew-2895433", "kew-2615007"), db = "tpl")
 #' }
 taxid2name <- function(x, db='ncbi', verbose=TRUE, warn=TRUE, ...){

--- a/R/ap_taxid2rank.R
+++ b/R/ap_taxid2rank.R
@@ -13,12 +13,12 @@
 #' @return character vector of ranks in the same order as the inputs
 #' @examples \dontrun{
 #' taxid2rank(c(3701, 9606))
-#' taxid2rank(c(154395, 154357, 23041, 154396), db="itis")
-#' taxid2rank(c('wfo-4000032377', 'wfo-0000541830'), db="wfo")
-#' taxid2rank("wfo-7000000057", db="wfo")
-#' taxid2rank(2877951, db="gbif")
-#' taxid2rank(c(2877951, 5386), db="gbif")
-#' taxid2rank(c(3960765, 3953606, 3953010), db="col")
+#' taxid2rank(c(154395, 154357, 23041, 154396), db = "itis")
+#' taxid2rank(c('wfo-4000032377', 'wfo-0000541830'), db = "wfo")
+#' taxid2rank("wfo-7000000057", db = "wfo")
+#' taxid2rank(2877951, db = "gbif")
+#' taxid2rank(c(2877951, 5386), db = "gbif")
+#' taxid2rank(c(3960765, 3953606, 3953010), db = "col")
 #' }
 taxid2rank <- function(x, db='ncbi', verbose=TRUE, warn=TRUE, ...){
   result <- ap_vector_dispatch(

--- a/R/ap_taxid2rank.R
+++ b/R/ap_taxid2rank.R
@@ -18,7 +18,7 @@
 #' taxid2rank("wfo-7000000057", db = "wfo")
 #' taxid2rank(2877951, db = "gbif")
 #' taxid2rank(c(2877951, 5386), db = "gbif")
-#' taxid2rank(c(3960765, 3953606, 3953010), db = "col")
+#' taxid2rank(c("C66T4", "C7ZVH", "TP"), db = "col")
 #' }
 taxid2rank <- function(x, db='ncbi', verbose=TRUE, warn=TRUE, ...){
   result <- ap_vector_dispatch(

--- a/R/db_download.R
+++ b/R/db_download.R
@@ -453,6 +453,13 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
     col_types = "icccccccccccccccccccccc"
   )
 
+  # create indices
+  RSQLite::dbExecute(db, 'CREATE UNIQUE INDEX id on gbif (taxonID)')
+  RSQLite::dbExecute(db, 'CREATE INDEX conname on gbif (canonicalName)')
+  RSQLite::dbExecute(db, 'CREATE INDEX sciname on gbif (scientificName)')
+  RSQLite::dbExecute(db, 'CREATE INDEX parname on gbif (parentNameUsageID)')
+
+  # disconnect
   RSQLite::dbDisconnect(db)
 
   mssg(verbose, 'cleaning up...')

--- a/R/db_download.R
+++ b/R/db_download.R
@@ -445,7 +445,7 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
   out <- readr::read_tsv_chunked(
     paste0(tdb_cache$cache_path_get(), "/gbif/Taxon.tsv"),
     callback = function(chunk, dummy) {
-      dbWriteTable(db, "gbif", chunk, append = T)
+      DBI::dbWriteTable(db, "gbif", chunk, append = T)
     },
     chunk_size = 10000,
     col_types = "icccccccccccccccccccccc"

--- a/R/db_download.R
+++ b/R/db_download.R
@@ -417,6 +417,7 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
   db_url <- "https://hosted-datasets.gbif.org/datasets/backbone/current/backbone.zip"
   db_path <- file.path(tdb_cache$cache_path_get(), 'gbif.sqlite')
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'backbone.zip')
+  db_path_dir <- file.path(tdb_cache$cache_path_get(), 'gbif')
 
   assert(verbose, "logical")
   assert(overwrite, "logical")
@@ -452,6 +453,7 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
 
   mssg(verbose, 'cleaning up...')
   unlink(db_path_file)
+  unlink(db_path_dir, recursive = TRUE)
 
   mssg(verbose, 'all done...')
   return(db_path)

--- a/R/db_download.R
+++ b/R/db_download.R
@@ -289,7 +289,7 @@ db_download_tpl <- function(verbose = TRUE, overwrite = FALSE) {
 #' @export
 #' @rdname db_download
 db_download_wfo <- function(verbose = TRUE, overwrite = FALSE) {
-  db_url <- "http://104.198.143.165/files/WFO_Backbone/_WFOCompleteBackbone/WFO_Backbone.zip" #nolint
+  db_url <- "https://zenodo.org/records/10425161/files/_DwC_backbone_R.zip?download=1" #nolint
   db_path <- file.path(tdb_cache$cache_path_get(), 'WFO_Backbone.zip')
   db_path_file <- file.path(tdb_cache$cache_path_get(), 'WFO_Backbone')
   class_file <- file.path(tdb_cache$cache_path_get(), 'WFO_Backbone/classification.csv')

--- a/R/db_download.R
+++ b/R/db_download.R
@@ -451,6 +451,8 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
     col_types = "icccccccccccccccccccccc"
   )
 
+  RSQLite::dbDisconnect(db)
+
   mssg(verbose, 'cleaning up...')
   unlink(db_path_file)
   unlink(db_path_dir, recursive = TRUE)

--- a/R/taxa_at.R
+++ b/R/taxa_at.R
@@ -25,7 +25,7 @@
 #' taxa_at("wfo-7000000057", rank = "order", db = "wfo")
 #' taxa_at(2877951, rank = "phylum", db = "gbif")
 #' taxa_at(c(2877951, 5386), rank = "family", db = "gbif")
-#' taxa_at(c(3960765, 3953606, 3953010), rank = "family", db = "col")
+#' taxa_at(c("C66T4", "C7ZVH", "TP"), rank = "family", db = "col")
 #' }
 taxa_at <- function(x, rank, db='ncbi', missing = "lower", verbose=TRUE,
   warn=TRUE, ...) {

--- a/R/taxa_at.R
+++ b/R/taxa_at.R
@@ -17,15 +17,15 @@
 #' @return list of data.frame's for each input taxon key, where each data.frame
 #' has fields: name, rank, id. When no results found, an empty data.frame
 #' @examples \dontrun{
-#' taxa_at(186803, rank = "order", db="ncbi", missing = "lower")
+#' taxa_at(186803, rank = "order", db = "ncbi", missing = "lower")
 #' taxa_at(c(186803, 541000, 216572, 186804, 31979,  186806),
 #'  rank = "family", missing = "lower")
 #' taxa_at(c(154395, 154357, 23041, 154396), rank = "family", db="itis")
-#' taxa_at(c('wfo-4000032377', 'wfo-0000541830'), rank = "family", db="wfo")
-#' taxa_at("wfo-7000000057", rank = "order", db="wfo")
-#' taxa_at(2877951, rank = "phylum", db="gbif")
-#' taxa_at(c(2877951, 5386), rank = "family", db="gbif")
-#' taxa_at(c(3960765, 3953606, 3953010), rank = "family", db="col")
+#' taxa_at(c('wfo-4000032377', 'wfo-0000541830'), rank = "family", db = "wfo")
+#' taxa_at("wfo-7000000057", rank = "order", db = "wfo")
+#' taxa_at(2877951, rank = "phylum", db = "gbif")
+#' taxa_at(c(2877951, 5386), rank = "family", db = "gbif")
+#' taxa_at(c(3960765, 3953606, 3953010), rank = "family", db = "col")
 #' }
 taxa_at <- function(x, rank, db='ncbi', missing = "lower", verbose=TRUE,
   warn=TRUE, ...) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,68 +26,32 @@ knitr::opts_chunk$set(
 [![cran version](https://www.r-pkg.org/badges/version/taxizedb)](https://cran.r-project.org/package=taxizedb)
 [![DOI](https://zenodo.org/badge/53961466.svg)](https://zenodo.org/badge/latestdoi/53961466)
 
-`taxizedb` - Tools for Working with Taxonomic Databases on your machine
+`taxizedb` - Tools for Working with Taxonomic Databases
 
 Docs: <https://docs.ropensci.org/taxizedb/>
 
-[taxize](https://github.com/ropensci/taxize) is a heavily used taxonomic toolbelt
-package in R - However, it makes web requests for nearly all methods. That is fine
-for most cases, but when the user has many, many names it is much more efficient
-to do requests to a local SQL database.
+`taxizedb` is an R package for interacting with taxonomic databases. Its functionality can be divided in two parts: 1. You can download the databases to your platform 2. You can query the downloaded databases to retrieve taxonomic information.
+
+This two step approach is different from tools which interact with web services for each query, and has a number of advantages:
+
+* Once you download a database you can work with it offline
+* Once you download a database querying it is super fast
+* As long as you store your database files all the queries in your analysis will be fully reproducible
 
 ## Data sources
 
-Not all taxonomic databases are publicly available, or possible to mash into a SQLized
-version. Taxonomic DB's supported:
+When you download a database with `taxizedb` it will automatically convert it to SQLite and then all query functions will interact with this SQLite database. However, not all taxonomic databases are publicly available, or can be converted to SQLite. The following databases are supported:
 
-- NCBI: text files are provided by NCBI, which we stitch into a sqlite db
-- ITIS: they provide a sqlite dump, which we use here
-- The PlantList: created from stitching together csv files. this
- source is no longer updated as far as we can tell. they say they've
- moved focus to the World Flora Online
-- Catalogue of Life: created from Darwin Core Archive dump.
-- GBIF: created from Darwin Core Archive dump. right now we only have
- the taxonomy table (called gbif), but will add the other tables in the
- darwin core archive later
-- Wikidata: aggregated taxonomy of Open Tree of Life, GLoBI and Wikidata. 
- On Zenodo, created by Joritt Poelen of GLOBI.
-- World Flora Online: http://www.worldfloraonline.org/
-
-Update schedule for databases:
-
-- NCBI: since `db_download_ncbi` creates the database when the function
-is called, it's updated whenever you run the function
-- ITIS: since ITIS provides the sqlite database as a download, you can
-delete the old file and run `db_download_itis` to get a new dump;
-they I think update the dumps every month or so
-- The PlantList: no longer updated, so you shouldn't need to download
-this after the first download. hosted on Amazon S3
-- Catalogue of Life: a GitHub Actions job runs once a day at 00:00 UTC,
-building the lastest COL data into a SQLite database thats hosted on
-Amazon S3
-- GBIF: a GitHub Actions job runs once a day at 00:00 UTC,
-building the lastest GBIF data into a SQLite database thats hosted on
-Amazon S3
-- Wikidata: last updated April 6, 2018. Scripts are available to 
-update the data if you prefer to do it yourself.
-- World Flora Online: since `db_download_wfo` creates the database when
-the function is called, it's updated whenever you run the function
-
- Links:
-
-- NCBI: ftp://ftp.ncbi.nih.gov/pub/taxonomy/
-- ITIS: https://www.itis.gov/downloads/index.html
-- The PlantList - http://www.theplantlist.org/
-- Catalogue of Life:
-  - latest monthly edition via https://www.catalogueoflife.org/data/download
-- GBIF: http://rs.gbif.org/datasets/backbone/
-- Wikidata: https://zenodo.org/record/1213477
-- World Flora Online: http://www.worldfloraonline.org/
+- [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy)
+- [ITIS](https://itis.gov/)
+- [The Plant List (TPL)](http://www.theplantlist.org/) - Note that The Plant List has been superseded by World Flora Online.
+- [World Flora Online (WFO)](http://www.worldfloraonline.org/)
+- [Catalogue of Life (COL)](https://www.catalogueoflife.org/)
+- [Global Biodiversity Information Facility (GBIF)](https://www.gbif.org/)
+- [Wikidata](https://zenodo.org/records/1213477)
 
 Get in touch [in the issues](https://github.com/ropensci/taxizedb/issues) with
 any ideas on new data sources.
-
-All databases are SQLite.
 
 ## Package API
 
@@ -106,9 +70,9 @@ This package for each data sources performs the following tasks:
 
 You can use the `src` connections with `dplyr`, etc. to do operations downstream. Or use the database connection to do raw SQL queries.
 
-## install
+## Installation
 
-cran version
+CRAN version
 
 ```{r eval=FALSE}
 install.packages("taxizedb")

--- a/README.md
+++ b/README.md
@@ -16,70 +16,44 @@ Downloads](https://cranlogs.r-pkg.org/badges/grand-total/taxizedb?color=blue)](h
 version](https://www.r-pkg.org/badges/version/taxizedb)](https://cran.r-project.org/package=taxizedb)
 [![DOI](https://zenodo.org/badge/53961466.svg)](https://zenodo.org/badge/latestdoi/53961466)
 
-`taxizedb` - Tools for Working with Taxonomic Databases on your machine
+`taxizedb` - Tools for Working with Taxonomic Databases
 
 Docs: <https://docs.ropensci.org/taxizedb/>
 
-[taxize](https://github.com/ropensci/taxize) is a heavily used taxonomic
-toolbelt package in R - However, it makes web requests for nearly all
-methods. That is fine for most cases, but when the user has many, many
-names it is much more efficient to do requests to a local SQL database.
+`taxizedb` is an R package for interacting with taxonomic databases. Its
+functionality can be divided in two parts: 1. You can download the
+databases to your platform 2. You can query the downloaded databases to
+retrieve taxonomic information.
+
+This two step approach is different from tools which interact with web
+services for each query, and has a number of advantages:
+
+- Once you download a database you can work with it offline
+- Once you download a database querying it is super fast
+- As long as you store your database files all the queries in your
+  analysis will be fully reproducible
 
 ## Data sources
 
-Not all taxonomic databases are publicly available, or possible to mash
-into a SQLized version. Taxonomic DB’s supported:
+When you download a database with `taxizedb` it will automatically
+convert it to SQLite and then all query functions will interact with
+this SQLite database. However, not all taxonomic databases are publicly
+available, or can be converted to SQLite. The following databases are
+supported:
 
-- NCBI: text files are provided by NCBI, which we stitch into a sqlite
-  db
-- ITIS: they provide a sqlite dump, which we use here
-- The PlantList: created from stitching together csv files. this source
-  is no longer updated as far as we can tell. they say they’ve moved
-  focus to the World Flora Online
-- Catalogue of Life: created from Darwin Core Archive dump.
-- GBIF: created from Darwin Core Archive dump. right now we only have
-  the taxonomy table (called gbif), but will add the other tables in the
-  darwin core archive later
-- Wikidata: aggregated taxonomy of Open Tree of Life, GLoBI and
-  Wikidata. On Zenodo, created by Joritt Poelen of GLOBI.
-- World Flora Online: <http://www.worldfloraonline.org/>
-
-Update schedule for databases:
-
-- NCBI: since `db_download_ncbi` creates the database when the function
-  is called, it’s updated whenever you run the function
-- ITIS: since ITIS provides the sqlite database as a download, you can
-  delete the old file and run `db_download_itis` to get a new dump; they
-  I think update the dumps every month or so
-- The PlantList: no longer updated, so you shouldn’t need to download
-  this after the first download. hosted on Amazon S3
-- Catalogue of Life: a GitHub Actions job runs once a day at 00:00 UTC,
-  building the lastest COL data into a SQLite database thats hosted on
-  Amazon S3
-- GBIF: a GitHub Actions job runs once a day at 00:00 UTC, building the
-  lastest GBIF data into a SQLite database thats hosted on Amazon S3
-- Wikidata: last updated April 6, 2018. Scripts are available to update
-  the data if you prefer to do it yourself.
-- World Flora Online: since `db_download_wfo` creates the database when
-  the function is called, it’s updated whenever you run the function
-
-Links:
-
-- NCBI: <ftp://ftp.ncbi.nih.gov/pub/taxonomy/>
-- ITIS: <https://www.itis.gov/downloads/index.html>
-- The PlantList - <http://www.theplantlist.org/>
-- Catalogue of Life:
-  - latest monthly edition via
-    <https://www.catalogueoflife.org/data/download>
-- GBIF: <http://rs.gbif.org/datasets/backbone/>
-- Wikidata: <https://zenodo.org/record/1213477>
-- World Flora Online: <http://www.worldfloraonline.org/>
+- [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy)
+- [ITIS](https://itis.gov/)
+- [The Plant List (TPL)](http://www.theplantlist.org/) - Note that The
+  Plant List has been superseded by World Flora Online.
+- [World Flora Online (WFO)](http://www.worldfloraonline.org/)
+- [Catalogue of Life (COL)](https://www.catalogueoflife.org/)
+- [Global Biodiversity Information Facility
+  (GBIF)](https://www.gbif.org/)
+- [Wikidata](https://zenodo.org/records/1213477)
 
 Get in touch [in the
 issues](https://github.com/ropensci/taxizedb/issues) with any ideas on
 new data sources.
-
-All databases are SQLite.
 
 ## Package API
 
@@ -100,9 +74,9 @@ This package for each data sources performs the following tasks:
 You can use the `src` connections with `dplyr`, etc. to do operations
 downstream. Or use the database connection to do raw SQL queries.
 
-## install
+## Installation
 
-cran version
+CRAN version
 
 ``` r
 install.packages("taxizedb")

--- a/man/children.Rd
+++ b/man/children.Rd
@@ -26,9 +26,9 @@ Retrieve immediate descendents of a taxon
 \examples{
 \dontrun{
 children(c(3700, 2))
-children(c(154395, 154357), db="itis")
-children("wfo-4000032377", db="wfo")
-children(2877951, db="gbif")
-children(3960765, db="col") # Abies
+children(c(154395, 154357), db = "itis")
+children("wfo-4000032377", db = "wfo")
+children(2877951, db = "gbif")
+children(3960765, db = "col") # Abies
 }
 }

--- a/man/children.Rd
+++ b/man/children.Rd
@@ -29,6 +29,6 @@ children(c(3700, 2))
 children(c(154395, 154357), db = "itis")
 children("wfo-4000032377", db = "wfo")
 children(2877951, db = "gbif")
-children(3960765, db = "col") # Abies
+children("C66T4", db = "col") # Abies Mill. Mill.
 }
 }

--- a/man/classification.Rd
+++ b/man/classification.Rd
@@ -33,6 +33,6 @@ classification(c(154395, 154357), db = "itis")
 classification(c("wfo-0000291463", "wfo-7000000057"), db = "wfo")
 classification(2878586, db = "gbif")
 classification(c(2878586, 2704179), db = "gbif")
-classification(3960765, db = "col") # Abies
+classification("C66T4", db = "col") # Abies Mill.
 }
 }

--- a/man/classification.Rd
+++ b/man/classification.Rd
@@ -29,10 +29,10 @@ identical to \code{taxize::classification()}
 \examples{
 \dontrun{
 classification(c(3702, 9606))
-classification(c(154395, 154357), db="itis")
-classification(c("wfo-0000291463", "wfo-7000000057"), db="wfo")
-classification(2878586, db="gbif")
-classification(c(2878586, 2704179), db="gbif")
-classification(3960765, db="col") # Abies
+classification(c(154395, 154357), db = "itis")
+classification(c("wfo-0000291463", "wfo-7000000057"), db = "wfo")
+classification(2878586, db = "gbif")
+classification(c(2878586, 2704179), db = "gbif")
+classification(3960765, db = "col") # Abies
 }
 }

--- a/man/name2taxid.Rd
+++ b/man/name2taxid.Rd
@@ -51,7 +51,7 @@ name2taxid(x=c('Arabidopsis thaliana', 'Quercus kelloggii'), db = "wfo",
 name2taxid("Austrobaileyaceae", db = "wfo")
 name2taxid("Quercus kelloggii", db = "gbif")
 name2taxid(c("Quercus", "Fabaceae", "Animalia"), db = "gbif")
-name2taxid(c("Abies", "Pinales", "Tracheophyta"), db = "col")
+name2taxid(c("Abies Mill.", "Pinales Gorozh.", "Tracheophyta"), db = "col")
 name2taxid(c("Abies mangifica", "Acanthopale aethiogermanica",
   "Acanthopale albosetulosa"), db = "tpl")
 }

--- a/man/taxa_at.Rd
+++ b/man/taxa_at.Rd
@@ -52,6 +52,6 @@ taxa_at(c('wfo-4000032377', 'wfo-0000541830'), rank = "family", db = "wfo")
 taxa_at("wfo-7000000057", rank = "order", db = "wfo")
 taxa_at(2877951, rank = "phylum", db = "gbif")
 taxa_at(c(2877951, 5386), rank = "family", db = "gbif")
-taxa_at(c(3960765, 3953606, 3953010), rank = "family", db = "col")
+taxa_at(c("C66T4", "C7ZVH", "TP"), rank = "family", db = "col")
 }
 }

--- a/man/taxa_at.Rd
+++ b/man/taxa_at.Rd
@@ -44,14 +44,14 @@ Get taxa at specific scientific ranks
 }
 \examples{
 \dontrun{
-taxa_at(186803, rank = "order", db="ncbi", missing = "lower")
+taxa_at(186803, rank = "order", db = "ncbi", missing = "lower")
 taxa_at(c(186803, 541000, 216572, 186804, 31979,  186806),
  rank = "family", missing = "lower")
 taxa_at(c(154395, 154357, 23041, 154396), rank = "family", db="itis")
-taxa_at(c('wfo-4000032377', 'wfo-0000541830'), rank = "family", db="wfo")
-taxa_at("wfo-7000000057", rank = "order", db="wfo")
-taxa_at(2877951, rank = "phylum", db="gbif")
-taxa_at(c(2877951, 5386), rank = "family", db="gbif")
-taxa_at(c(3960765, 3953606, 3953010), rank = "family", db="col")
+taxa_at(c('wfo-4000032377', 'wfo-0000541830'), rank = "family", db = "wfo")
+taxa_at("wfo-7000000057", rank = "order", db = "wfo")
+taxa_at(2877951, rank = "phylum", db = "gbif")
+taxa_at(c(2877951, 5386), rank = "family", db = "gbif")
+taxa_at(c(3960765, 3953606, 3953010), rank = "family", db = "col")
 }
 }

--- a/man/taxid2name.Rd
+++ b/man/taxid2name.Rd
@@ -34,7 +34,7 @@ taxid2name(c('wfo-0000541830', 'wfo-0000291463'), db = "wfo")
 taxid2name("wfo-7000000057", db = "wfo")
 taxid2name(2877951, db = "gbif")
 taxid2name(c(2877951, 5386), db = "gbif")
-taxid2name(c(3960765, 3953606, 3953010), db = "col")
+taxid2name(c("C66T4", "C7ZVH", "TP"), db = "col")
 taxid2name(c("kew-2614538", "kew-2895433", "kew-2615007"), db = "tpl")
 }
 }

--- a/man/taxid2name.Rd
+++ b/man/taxid2name.Rd
@@ -31,10 +31,10 @@ Convert taxon IDs to scientific names
 taxid2name(c(3702, 9606))
 taxid2name(c(154395, 154357, 23041, 154396), db = "itis")
 taxid2name(c('wfo-0000541830', 'wfo-0000291463'), db = "wfo")
-taxid2name("wfo-7000000057", db="wfo")
-taxid2name(2877951, db="gbif")
-taxid2name(c(2877951, 5386), db="gbif")
-taxid2name(c(3960765, 3953606, 3953010), db="col")
-taxid2name(c("kew-2614538", "kew-2895433", "kew-2615007"), db="tpl")
+taxid2name("wfo-7000000057", db = "wfo")
+taxid2name(2877951, db = "gbif")
+taxid2name(c(2877951, 5386), db = "gbif")
+taxid2name(c(3960765, 3953606, 3953010), db = "col")
+taxid2name(c("kew-2614538", "kew-2895433", "kew-2615007"), db = "tpl")
 }
 }

--- a/man/taxid2rank.Rd
+++ b/man/taxid2rank.Rd
@@ -35,6 +35,6 @@ taxid2rank(c('wfo-4000032377', 'wfo-0000541830'), db = "wfo")
 taxid2rank("wfo-7000000057", db = "wfo")
 taxid2rank(2877951, db = "gbif")
 taxid2rank(c(2877951, 5386), db = "gbif")
-taxid2rank(c(3960765, 3953606, 3953010), db = "col")
+taxid2rank(c("C66T4", "C7ZVH", "TP"), db = "col")
 }
 }

--- a/man/taxid2rank.Rd
+++ b/man/taxid2rank.Rd
@@ -30,11 +30,11 @@ Convert taxon IDs to scientific ranks
 \examples{
 \dontrun{
 taxid2rank(c(3701, 9606))
-taxid2rank(c(154395, 154357, 23041, 154396), db="itis")
-taxid2rank(c('wfo-4000032377', 'wfo-0000541830'), db="wfo")
-taxid2rank("wfo-7000000057", db="wfo")
-taxid2rank(2877951, db="gbif")
-taxid2rank(c(2877951, 5386), db="gbif")
-taxid2rank(c(3960765, 3953606, 3953010), db="col")
+taxid2rank(c(154395, 154357, 23041, 154396), db = "itis")
+taxid2rank(c('wfo-4000032377', 'wfo-0000541830'), db = "wfo")
+taxid2rank("wfo-7000000057", db = "wfo")
+taxid2rank(2877951, db = "gbif")
+taxid2rank(c(2877951, 5386), db = "gbif")
+taxid2rank(c(3960765, 3953606, 3953010), db = "col")
 }
 }

--- a/man/taxizedb-package.Rd
+++ b/man/taxizedb-package.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/taxizedb-package.R
 \docType{package}
 \name{taxizedb-package}
+\alias{-package}
 \alias{taxizedb-package}
 \alias{taxizedb}
 \title{taxizedb}

--- a/man/taxizedb-package.Rd
+++ b/man/taxizedb-package.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/taxizedb-package.R
 \docType{package}
 \name{taxizedb-package}
-\alias{-package}
 \alias{taxizedb-package}
 \alias{taxizedb}
 \title{taxizedb}

--- a/tests/testthat/test-children.R
+++ b/tests/testthat/test-children.R
@@ -48,8 +48,10 @@ test_that("children works for GBIF", {
   expect_is(unclass(res), "list")
   expect_is(res[[1]], "tbl")
   expect_named(res[[1]], c("id", "name", "rank"))
-  expect_equal(unique(res[[1]]$rank),
-    c("species", "variety", "subspecies", "form", "unranked"))
+  expect_equal(
+    sort(unique(res[[1]]$rank)),
+    c("form", "species", "subspecies", "unranked", "variety")
+  )
 })
 
 test_that("missing values are consistent with taxize", {

--- a/tests/testthat/test-taxa_at.R
+++ b/tests/testthat/test-taxa_at.R
@@ -15,7 +15,7 @@ test_that("taxa_at", {
   for (i in list(ncbi_1, ncbi_2, itis, wfo_1, wfo_2, gbif_1, gbif_2)) expect_named(i[[1]], c("name", "rank", "id"))
   
   skip_on_ci()
-  col <- taxa_at(c(3960765, 3953606, 3953010), rank = "family", db="col")
+  col <- taxa_at(c("C66T4", "C7ZVH", "TP"), rank = "family", db = "col")
   expect_is(col, "taxa_at")
   expect_is(unclass(col), "list")
   expect_is(col[[1]], "data.frame")


### PR DESCRIPTION
Related to issues #77, #82, #83.

This PR implements conversion to SQLite locally within `taxizedb`. Orginal code for conversion to SQLite:

- COL: https://github.com/sckott/col-sql
- GBIF: https://github.com/sckott/gbif-backbone-sql
- TPL: https://github.com/sckott/tpl-sqlite

These were re-implemented within the respective `db_download_*()` functions.

The URL for COL seemed to point to GBIF so I replaced the URL with a new one.

The URL for WFO did not work because of an expired certificate. The new Zenodo URL works properly.