### PR TITLE
TPL is no longer available for download

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,4 @@ Imports:
 Suggests:
     testthat,
     taxize
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+dev
+==============
+
+## DEFUNCT
+
+* TPL is no longer available so `db_download_tpl()` will fail. However, if the database was downloaded earlier, it can still be queried using `taxizedb` functions.
+
+
 taxizedb 0.3.1
 ==============
 

--- a/R/db_download.R
+++ b/R/db_download.R
@@ -8,6 +8,9 @@
 #' @return (character) path to the downloaded SQL database
 #' @details Downloads sql database, cleans up unneeded files, returns path
 #' to sql file
+#' @note The Plant List (TPL) is no longer accessible. If you have a copy of the
+#' sqlite database you can still use the rest of the TPL functions with it. We 
+#' suggest using the World Flora Online (WFO) database as a replacement.
 #' @seealso [tdb_cache]
 #' @examples \dontrun{
 #' # ITIS
@@ -16,7 +19,6 @@
 #'
 #' # Plantlist
 #' # db_download_tpl()
-#' # db_download_tpl(overwrite=TRUE) # overwrite - download again
 #' # src_tpl()
 #'
 #' # COL
@@ -263,29 +265,13 @@ db_download_tpl <- function(verbose = TRUE, overwrite = FALSE) {
   if (file.exists(final_file) && !overwrite) {
     mssg(verbose, "Database already exists, returning old file")
     return(final_file)
+  } else {
+    stop(
+      "The Plant List (TPL) is no longer accessible. If you have a copy of the
+      sqlite database you can still use the rest of the TPL functions with it. 
+      We suggest using the World Flora Online (WFO) database as a replacement."
+    )
   }
-  unlink(final_file, force = TRUE)
-
-  # make home dir if not already present
-  tdb_cache$mkdir()
-  # download data
-  taxize::tpl_get(db_path_dir)
-  # convert to sqlite 
-  files <- list.files(db_path_dir, full.names = TRUE)
-  df <- data.table::rbindlist(lapply(files, data.table::fread), fill = TRUE)
-  names(df) <- gsub("\\s", "_", tolower(names(df)))
-  df$scientificname <- paste(df$genus, df$species)
-  x <- DBI::dbConnect(RSQLite::SQLite(), final_file)
-  DBI::dbWriteTable(x, "tpl", df)
-  # create indices
-  RSQLite::dbExecute(x, 'CREATE UNIQUE INDEX id ON tpl (id)')
-  RSQLite::dbExecute(x, 'CREATE INDEX sciname ON tpl (scientificname)')
-  # disconnect
-  DBI::dbDisconnect(x)
-  # clean up
-  unlink(db_path_dir, recursive = TRUE)
-  # return path
-  return(final_file)
 }
 
 #' @export

--- a/R/db_load.R
+++ b/R/db_load.R
@@ -1,6 +1,7 @@
-#' Load taxonomic databases - NO LONGER NEEDED
+#' Load taxonomic databases
 #' 
-#' Use [db_download] then [src_taxizedb]
+#' This family of functions has been removed. Use [db_download] then 
+#' [src_taxizedb].
 #'
 #' @export
 #' @param ... ignored

--- a/R/taxizedb-package.R
+++ b/R/taxizedb-package.R
@@ -90,8 +90,11 @@
 #' hiers %>% select(TSN, level)
 #'
 #' # data source: The PlantList
-#' ## download tpl datababase
-#' db_download_tpl()
+#' 
+#' "The Plant List (TPL) is no longer accessible. If you have a copy of the
+#' sqlite database you can still use the rest of the TPL functions with it.
+#' We suggest using the World Flora Online (WFO) database as a replacement." 
+#' 
 #' ## connecto the tpl database
 #' src <- src_tpl()
 #' ## do queries

--- a/README.Rmd
+++ b/README.Rmd
@@ -44,7 +44,6 @@ When you download a database with `taxizedb` it will automatically convert it to
 
 - [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy)
 - [ITIS](https://itis.gov/)
-- [The Plant List (TPL)](http://www.theplantlist.org/) - Note that The Plant List has been superseded by World Flora Online.
 - [World Flora Online (WFO)](http://www.worldfloraonline.org/)
 - [Catalogue of Life (COL)](https://www.catalogueoflife.org/)
 - [Global Biodiversity Information Facility (GBIF)](https://www.gbif.org/)
@@ -52,6 +51,10 @@ When you download a database with `taxizedb` it will automatically convert it to
 
 Get in touch [in the issues](https://github.com/ropensci/taxizedb/issues) with
 any ideas on new data sources.
+
+## Data sources - legacy support
+
+[The Plant List (TPL)](https://en.wikipedia.org/wiki/The_Plant_List) has been replaced by World Flora Online. The website seems to be down so `taxizedb` can no longer facilitate new downloads. However, already downloaded database files can still be queried using `taxizedb` functions, for reproducibility.
 
 ## Package API
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ supported:
 
 - [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy)
 - [ITIS](https://itis.gov/)
-- [The Plant List (TPL)](http://www.theplantlist.org/) - Note that The
-  Plant List has been superseded by World Flora Online.
 - [World Flora Online (WFO)](http://www.worldfloraonline.org/)
 - [Catalogue of Life (COL)](https://www.catalogueoflife.org/)
 - [Global Biodiversity Information Facility
@@ -54,6 +52,14 @@ supported:
 Get in touch [in the
 issues](https://github.com/ropensci/taxizedb/issues) with any ideas on
 new data sources.
+
+## Data sources - legacy support
+
+[The Plant List (TPL)](https://en.wikipedia.org/wiki/The_Plant_List) has
+been replaced by World Flora Online. The website seems to be down so
+`taxizedb` can no longer facilitate new downloads. However, already
+downloaded database files can still be queried using `taxizedb`
+functions, for reproducibility.
 
 ## Package API
 

--- a/man/db_download.Rd
+++ b/man/db_download.Rd
@@ -41,6 +41,11 @@ Download taxonomic databases
 Downloads sql database, cleans up unneeded files, returns path
 to sql file
 }
+\note{
+The Plant List (TPL) is no longer accessible. If you have a copy of the
+sqlite database you can still use the rest of the TPL functions with it. We
+suggest using the World Flora Online (WFO) database as a replacement.
+}
 \examples{
 \dontrun{
 # ITIS
@@ -49,7 +54,6 @@ to sql file
 
 # Plantlist
 # db_download_tpl()
-# db_download_tpl(overwrite=TRUE) # overwrite - download again
 # src_tpl()
 
 # COL

--- a/man/db_load-defunct.Rd
+++ b/man/db_load-defunct.Rd
@@ -8,7 +8,7 @@
 \alias{db_load_gbif}
 \alias{db_load_ncbi}
 \alias{db_load_wikidata}
-\title{Load taxonomic databases - NO LONGER NEEDED}
+\title{Load taxonomic databases}
 \usage{
 db_load_itis(...)
 
@@ -26,5 +26,6 @@ db_load_wikidata(...)
 \item{...}{ignored}
 }
 \description{
-Use \link{db_download} then \link{src_taxizedb}
+This family of functions has been removed. Use \link{db_download} then
+\link{src_taxizedb}.
 }

--- a/man/taxizedb-package.Rd
+++ b/man/taxizedb-package.Rd
@@ -95,8 +95,11 @@ hiers <- src \%>\% tbl("hierarchy")
 hiers \%>\% select(TSN, level)
 
 # data source: The PlantList
-## download tpl datababase
-db_download_tpl()
+
+"The Plant List (TPL) is no longer accessible. If you have a copy of the
+sqlite database you can still use the rest of the TPL functions with it.
+We suggest using the World Flora Online (WFO) database as a replacement." 
+
 ## connecto the tpl database
 src <- src_tpl()
 ## do queries

--- a/man/taxizedb-package.Rd
+++ b/man/taxizedb-package.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/taxizedb-package.R
 \docType{package}
 \name{taxizedb-package}
+\alias{-package}
 \alias{taxizedb-package}
 \alias{taxizedb}
 \title{taxizedb}

--- a/tests/testthat/test-children.R
+++ b/tests/testthat/test-children.R
@@ -64,11 +64,17 @@ test_that("missing values are consistent with taxize", {
 })
 
 test_that('children fails well', {
-  # tpl not supported
-  expect_error(
-    children("Poa", db = "tpl"),
-    "TPL database is not supported"
-  )
+
+  # TPL is no longer accessible. We can only test locally.
+  file <- file.path(tdb_cache$cache_path_get(), 'plantlist.sqlite')
+  if (file.exists(file)) {
+    # tpl not supported
+    expect_error(
+      children("Poa", db = "tpl"),
+      "TPL database is not supported"
+    )
+  }
+  
   # abc does not exist
   expect_error(
     children("Poa annua", db = "abc"),

--- a/tests/testthat/test-classification.R
+++ b/tests/testthat/test-classification.R
@@ -118,11 +118,17 @@ test_that('classification handles mixed inputs', {
 })
 
 test_that('classification fails well', {
-  # tpl not supported
-  expect_error(
-    classification("Poa annua", db = "tpl"),
-    "TPL database is not supported"
-  )
+
+  # TPL is no longer accessible. We can only test locally.
+  file <- file.path(tdb_cache$cache_path_get(), 'plantlist.sqlite')
+  if (file.exists(file)) {
+    # tpl not supported
+    expect_error(
+      classification("Poa annua", db = "tpl"),
+      "TPL database is not supported"
+    )
+  }
+
   # abc does not exist
   expect_error(
     classification("Poa annua", db = "abc"),

--- a/tests/testthat/test-db_download.R
+++ b/tests/testthat/test-db_download.R
@@ -11,3 +11,20 @@ test_that("db_download - are functions", {
   expect_named(formals(db_download_itis), c("verbose", "overwrite"))
   expect_named(formals(db_download_tpl), c("verbose", "overwrite"))
 })
+
+test_that("db_download_tpl()", {
+  file <- file.path(tdb_cache$cache_path_get(), 'plantlist.sqlite')
+  if (file.exists(file)) {
+    # existing file can be imported
+    suppressMessages(expect_no_error(db_download_tpl()))
+    expect_equal(
+      capture_messages(db_download_tpl()),
+      "Database already exists, returning old file\n"
+    )
+    # existing file cannot be updated
+    expect_error(db_download_tpl(overwrite = TRUE))
+  } else {
+    # new file cannot be downloaded
+    expect_error(db_download_tpl())
+  }
+})

--- a/tests/testthat/test-downstream.R
+++ b/tests/testthat/test-downstream.R
@@ -36,12 +36,19 @@ test_that("downstream works with GBIF", {
   expect_named(x[[1]], c("id", "name", "rank"))
 })
 
+# TPL is no longer accessible. We can only test locally.
+test_that('downstream fails well', { 
+  file <- file.path(tdb_cache$cache_path_get(), 'plantlist.sqlite')
+  if (file.exists(file)) {
+    # tpl not supported
+    expect_error(
+      downstream("Poa", db = "tpl"),
+      "TPL database is not supported"
+    )
+  }
+})
+
 test_that('downstream fails well', {
-  # tpl not supported
-  expect_error(
-    downstream("Poa", db = "tpl"),
-    "TPL database is not supported"
-  )
   # abc does not exist
   expect_error(
     downstream("Poa annua", db = "abc"),

--- a/tests/testthat/test-realthing.R
+++ b/tests/testthat/test-realthing.R
@@ -9,7 +9,6 @@ test_that("We can actually download, load, and query all databases", {
   ## These should load from cache if we already have the download!
   gbif <- db_download_gbif()
   itis <- db_download_itis()
-  tpl <- db_download_tpl()
   col <- db_download_col()
   ncbi <- db_download_ncbi()
   wfo <- db_download_wfo()
@@ -25,9 +24,15 @@ test_that("We can actually download, load, and query all databases", {
   ## Load the actual data:
   gbif_db <- src_gbif()
   itis_db <- src_itis()
-  tpl_db <- src_tpl()
   col_db <- src_col()
   ncbi_db <- src_ncbi()
   wfo_db <- src_wfo()
   wikitaxa_db <- src_wikidata()
+
+  # TPL is no longer accessible. We can only test locally.
+  file <- file.path(tdb_cache$cache_path_get(), 'plantlist.sqlite')
+  if (file.exists(file)) {
+    tpl <- db_download_tpl()
+    tpl_db <- src_tpl()
+  }
 })


### PR DESCRIPTION
It seems the TPL website was turned off which broke a number of tests. This PR fixes these tests while also maintaining legacy support for already downloaded databases.

The only change in user experience is that `db_download_tpl()` no longer attempts to download the database. However, it still returns the database if it is locally available (good for reproducibility).

The PR also updates TPL tests so they will only run if a database is locally available.
