### PR TITLE
Fix checks on macOS

### DIFF
--- a/R/db_download.R
+++ b/R/db_download.R
@@ -489,6 +489,8 @@ db_download_gbif <- function(verbose = TRUE, overwrite = FALSE) {
     paste0(tdb_cache$cache_path_get(), "/gbif/Taxon.tsv"),
     callback = function(chunk, dummy) {
       DBI::dbWriteTable(db, "gbif", chunk, append = T)
+      rm(chunk)
+      gc()
     },
     chunk_size = 10000,
     col_types = "icccccccccccccccccccccc"


### PR DESCRIPTION
Related to #88.

Checks failed on macOS. The error message suggests the issue has to do with memory limitation. My understanding is that for some reason R is holding on to the requested memory and not giving it back to the OS. With this PR I am trying to resolve this by explicitly calling `gc()` to give it back to the OS.
