### PR TITLE
Manually remove a line from a man page to fix checks

### DIFF
--- a/man/taxizedb-package.Rd
+++ b/man/taxizedb-package.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/taxizedb-package.R
 \docType{package}
 \name{taxizedb-package}
-\alias{-package}
 \alias{taxizedb-package}
 \alias{taxizedb}
 \title{taxizedb}


### PR DESCRIPTION
Related to issue #91.

R CMD check returns this note:
Invalid package aliases in Rd file 'taxizedb-package.Rd': '-package'

I could not find a better way to eliminate this note but to manually delete it from the man page.