### PR TITLE
Remove library() from tests use taxize conditionally

### DIFF
--- a/tests/testthat/test-classification.R
+++ b/tests/testthat/test-classification.R
@@ -1,88 +1,92 @@
 context("classification")
 skip_on_cran()
 skip_if_not_installed("taxize")
-library(taxize, quietly = TRUE, warn.conflicts = FALSE)
 
-test_that("taxizedb::classification == taxize::classification", {
-  taxa_ids <- c(9606, 3702)
-  taxa_names <- c("Homo sapiens", "Arabidopsis thaliana")
-  taxa_names2 <- c("thale cress", "Homo_sapiens")
-
-  # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
-  # ENTREZ api not using the same data as is in the dump
-  # expect_equal(
-  #   taxize::classification(taxa_ids, db='ncbi', messages = FALSE),
-  #   taxizedb::classification(taxa_ids, db='ncbi', verbose = FALSE)
-  # )
+if (!requireNamespace("taxize", quietly = TRUE)) {
+  skip("taxize not installed; skipping tests that require it")
+} else {
   
-  # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
-  # ENTREZ api not using the same data as is in the dump
-  # expect_equal(
-  #   taxize::classification(taxa_names, db='ncbi', messages = FALSE),
-  #   taxizedb::classification(taxa_names, db='ncbi')
-  # )
+  test_that("taxizedb::classification == taxize::classification", {
+    taxa_ids <- c(9606, 3702)
+    taxa_names <- c("Homo sapiens", "Arabidopsis thaliana")
+    taxa_names2 <- c("thale cress", "Homo_sapiens")
+    
+    # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
+    # ENTREZ api not using the same data as is in the dump
+    # expect_equal(
+    #   taxize::classification(taxa_ids, db='ncbi', messages = FALSE),
+    #   taxizedb::classification(taxa_ids, db='ncbi', verbose = FALSE)
+    # )
+    
+    # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
+    # ENTREZ api not using the same data as is in the dump
+    # expect_equal(
+    #   taxize::classification(taxa_names, db='ncbi', messages = FALSE),
+    #   taxizedb::classification(taxa_names, db='ncbi')
+    # )
+    
+    # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
+    # ENTREZ api not using the same data as is in the dump
+    # input names are preserved (even if incorrect)
+    # expect_equal(
+    #   taxize::classification(taxa_names2, db='ncbi', messages = FALSE),
+    #   taxizedb::classification(taxa_names2, db='ncbi')
+    # )
+  })
   
-  # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
-  # ENTREZ api not using the same data as is in the dump
-  # input names are preserved (even if incorrect)
-  # expect_equal(
-  #   taxize::classification(taxa_names2, db='ncbi', messages = FALSE),
-  #   taxizedb::classification(taxa_names2, db='ncbi')
-  # )
-})
-
-test_that("classification is case insensitive", {
-  taxa_names <- c('homo sapiens', 'PIG', 'zea_mays')
-  ## FIXME: none of those are equivalent
-  ## slight differences between them
-  # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
-  # ENTREZ api not using the same data as is in the dump
-  # expect_equal(
-  #   taxize::classification(taxa_names, db='ncbi', messages = FALSE),
-  #   taxizedb::classification(taxa_names, db='ncbi')
-  # )
-})
-
-test_that('classification handles invalid ids', {
-  # FIXME: unfortunately, now taxize gives character(0) for classification with ncbi
-  # taxa_ids1 <- 9999999999
-  # taxa_ids2 <- c(9999999999, 8888888888)
-  # taxa_ids3 <- c(8888888888, 3702)
-  # expect_equal(
-  #   taxize::classification(taxa_ids1, db='ncbi', messages = FALSE),
-  #   taxizedb::classification(taxa_ids1, db='ncbi', verbose = FALSE)
-  # )
-  # expect_equal(
-  #   taxize::classification(taxa_ids2, db='ncbi', messages = FALSE),
-  #   taxizedb::classification(taxa_ids2, db='ncbi', verbose = FALSE)
-  # )
-  # expect_equal(
-  #   taxize::classification(taxa_ids3, db='ncbi', messages = FALSE),
-  #   taxizedb::classification(taxa_ids3, db='ncbi', verbose = FALSE)
-  # )
-})
-
-test_that('classification handles invalid names', {
-  taxa_names1 <- 'asdfasdf'
-  taxa_names2 <- c('asdfasdf', 'qwerqwer')
-  taxa_names3 <- c('pig', 'asdfasdf')
-  expect_equal(
-    suppressWarnings(taxize::classification(taxa_names1, db='ncbi',
-      messages = FALSE)),
-    taxizedb::classification(taxa_names1, db='ncbi', verbose = FALSE)
-  )
-  expect_equal(
-    suppressWarnings(taxize::classification(taxa_names2, db='ncbi',
-      messages = FALSE)),
-    taxizedb::classification(taxa_names2, db='ncbi', verbose = FALSE)
-  )
-  ## FIXME: none of those are equivalent
-  ## slight differences between them
-  # expect_equal(
-  #   taxize::classification(taxa_names3, db='ncbi'),
-  #   taxizedb::classification(taxa_names3, db='ncbi')
-  # )
-})
+  test_that("classification is case insensitive", {
+    taxa_names <- c('homo sapiens', 'PIG', 'zea_mays')
+    ## FIXME: none of those are equivalent
+    ## slight differences between them
+    # FIXME: "clade" (taxizedb dump) vs. "no rank" (taxize)
+    # ENTREZ api not using the same data as is in the dump
+    # expect_equal(
+    #   taxize::classification(taxa_names, db='ncbi', messages = FALSE),
+    #   taxizedb::classification(taxa_names, db='ncbi')
+    # )
+  })
+  
+  test_that('classification handles invalid ids', {
+    # FIXME: unfortunately, now taxize gives character(0) for classification with ncbi
+    # taxa_ids1 <- 9999999999
+    # taxa_ids2 <- c(9999999999, 8888888888)
+    # taxa_ids3 <- c(8888888888, 3702)
+    # expect_equal(
+    #   taxize::classification(taxa_ids1, db='ncbi', messages = FALSE),
+    #   taxizedb::classification(taxa_ids1, db='ncbi', verbose = FALSE)
+    # )
+    # expect_equal(
+    #   taxize::classification(taxa_ids2, db='ncbi', messages = FALSE),
+    #   taxizedb::classification(taxa_ids2, db='ncbi', verbose = FALSE)
+    # )
+    # expect_equal(
+    #   taxize::classification(taxa_ids3, db='ncbi', messages = FALSE),
+    #   taxizedb::classification(taxa_ids3, db='ncbi', verbose = FALSE)
+    # )
+  })
+  
+  test_that('classification handles invalid names', {
+    taxa_names1 <- 'asdfasdf'
+    taxa_names2 <- c('asdfasdf', 'qwerqwer')
+    taxa_names3 <- c('pig', 'asdfasdf')
+    expect_equal(
+      suppressWarnings(taxize::classification(taxa_names1, db='ncbi',
+                                              messages = FALSE)),
+      taxizedb::classification(taxa_names1, db='ncbi', verbose = FALSE)
+    )
+    expect_equal(
+      suppressWarnings(taxize::classification(taxa_names2, db='ncbi',
+                                              messages = FALSE)),
+      taxizedb::classification(taxa_names2, db='ncbi', verbose = FALSE)
+    )
+    ## FIXME: none of those are equivalent
+    ## slight differences between them
+    # expect_equal(
+    #   taxize::classification(taxa_names3, db='ncbi'),
+    #   taxizedb::classification(taxa_names3, db='ncbi')
+    # )
+  })
+}
 
 test_that('classification(NULL) == list()', {
   expect_equal(

--- a/tests/testthat/test-realthing.R
+++ b/tests/testthat/test-realthing.R
@@ -1,7 +1,3 @@
-library(dplyr)
-library(dbplyr)
-library(taxizedb)
-
 test_that("We can actually download, load, and query all databases", {
 
   testthat::skip_if_not(Sys.getenv("taxizedb_docker") == "test" )

--- a/tests/testthat/test-sql_collect.R
+++ b/tests/testthat/test-sql_collect.R
@@ -2,10 +2,6 @@ context("sql_collect")
 
 skip_on_cran()
 
-library(dplyr, quietly = TRUE, warn.conflicts = FALSE)
-library(DBI, quietly = TRUE, warn.conflicts = FALSE)
-library(RSQLite, quietly = TRUE, warn.conflicts = FALSE)
-
 test_that("sql_collect works", {
   # src
   # src <- dplyr::src_sqlite("irisdb.sqlite", create = TRUE)


### PR DESCRIPTION
Related to #91.

CRAN Team flagged that we can only use suggested packages conditionally, if available. This PR updates tests such that tests which use the suggested package `taxize` are skipped if the package is not available. While at it, I also removed `library()` for packages that are imported anyway.